### PR TITLE
Fix typos in code comments across all example files

### DIFF
--- a/SDKInitializer.js
+++ b/SDKInitializer.js
@@ -2,7 +2,7 @@ import * as SDK from "@zoho-corp/office-integrator-sdk";
 
 class SDKInitializer {
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -10,7 +10,7 @@ class SDKInitializer {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-            .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+            .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
             .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
             .build();
 

--- a/document-apis/coedit_document.js
+++ b/document-apis/coedit_document.js
@@ -17,7 +17,7 @@ class CoEditDocument {
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
             //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be created for document already exists with Zoho.
+            //then session will be created for the document that already exists with Zoho.
             documentInfo.setDocumentId("1000");
 
             createDocumentParameters.setDocumentInfo(documentInfo);

--- a/document-apis/coedit_document.js
+++ b/document-apis/coedit_document.js
@@ -5,7 +5,7 @@ class CoEditDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -15,9 +15,9 @@ class CoEditDocument {
             var documentInfo = new SDK.V1.DocumentInfo();
 
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
-            //Note: Make sure the document already exist in Zoho server for below given document id.
+            //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be create for document already exist with Zoho.
+            //then session will be created for document already exists with Zoho.
             documentInfo.setDocumentId("1000");
 
             createDocumentParameters.setDocumentInfo(documentInfo);
@@ -99,7 +99,7 @@ class CoEditDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -108,7 +108,7 @@ class CoEditDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -116,7 +116,7 @@ class CoEditDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/compare_document.js
+++ b/document-apis/compare_document.js
@@ -7,7 +7,7 @@ class CompareDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -51,7 +51,7 @@ class CompareDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -60,7 +60,7 @@ class CompareDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -68,7 +68,7 @@ class CompareDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/convert_document.js
+++ b/document-apis/convert_document.js
@@ -7,7 +7,7 @@ class ConvertDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -55,7 +55,7 @@ class ConvertDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -64,7 +64,7 @@ class ConvertDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -72,7 +72,7 @@ class ConvertDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/create_document.js
+++ b/document-apis/create_document.js
@@ -5,7 +5,7 @@ class CreateDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -14,7 +14,7 @@ class CreateDocument {
 
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("New Document");
 
@@ -120,7 +120,7 @@ class CreateDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -129,7 +129,7 @@ class CreateDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -137,7 +137,7 @@ class CreateDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/create_merge_template.js
+++ b/document-apis/create_merge_template.js
@@ -7,7 +7,7 @@ class CreateMergeTemplate {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -34,7 +34,7 @@ class CreateMergeTemplate {
 
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("Graphic-Design-Proposal.docx");
 
@@ -139,7 +139,7 @@ class CreateMergeTemplate {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -148,7 +148,7 @@ class CreateMergeTemplate {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -156,7 +156,7 @@ class CreateMergeTemplate {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/delete_document.js
+++ b/document-apis/delete_document.js
@@ -5,7 +5,7 @@ class DeleteDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -34,7 +34,7 @@ class DeleteDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -43,7 +43,7 @@ class DeleteDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -51,7 +51,7 @@ class DeleteDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/delete_document_session.js
+++ b/document-apis/delete_document_session.js
@@ -5,7 +5,7 @@ class DeleteDocumentSession {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -33,7 +33,7 @@ class DeleteDocumentSession {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -42,7 +42,7 @@ class DeleteDocumentSession {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -50,7 +50,7 @@ class DeleteDocumentSession {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/edit_document.js
+++ b/document-apis/edit_document.js
@@ -7,7 +7,7 @@ class EditDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -26,7 +26,7 @@ class EditDocument {
 
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("Graphic-Design-Proposal.docx");
 
@@ -127,7 +127,7 @@ class EditDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -136,7 +136,7 @@ class EditDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -144,7 +144,7 @@ class EditDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/get_all_sessions.js
+++ b/document-apis/get_all_sessions.js
@@ -5,7 +5,7 @@ class GetAllSessions {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -52,7 +52,7 @@ class GetAllSessions {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -61,7 +61,7 @@ class GetAllSessions {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -69,7 +69,7 @@ class GetAllSessions {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/get_document_detail.js
+++ b/document-apis/get_document_detail.js
@@ -5,7 +5,7 @@ class GetDocumentDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -41,7 +41,7 @@ class GetDocumentDetail {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -50,7 +50,7 @@ class GetDocumentDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -58,7 +58,7 @@ class GetDocumentDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/get_merge_fields.js
+++ b/document-apis/get_merge_fields.js
@@ -7,7 +7,7 @@ class GetFields {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -39,7 +39,7 @@ class GetFields {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -48,7 +48,7 @@ class GetFields {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -56,7 +56,7 @@ class GetFields {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/get_session_detail.js
+++ b/document-apis/get_session_detail.js
@@ -5,7 +5,7 @@ class GetSessionDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -37,7 +37,7 @@ class GetSessionDetail {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -46,7 +46,7 @@ class GetSessionDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -54,7 +54,7 @@ class GetSessionDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/merge_and_deliver.js
+++ b/document-apis/merge_and_deliver.js
@@ -7,7 +7,7 @@ class MergeAndDeliver {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -68,7 +68,7 @@ class MergeAndDeliver {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -77,7 +77,7 @@ class MergeAndDeliver {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -85,7 +85,7 @@ class MergeAndDeliver {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/merge_and_download.js
+++ b/document-apis/merge_and_download.js
@@ -4,7 +4,7 @@ const __dirname = import.meta.dirname;
 
 class MergeAndDownload {
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -12,7 +12,7 @@ class MergeAndDownload {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 
@@ -34,7 +34,7 @@ class MergeAndDownload {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -95,7 +95,7 @@ class MergeAndDownload {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }

--- a/document-apis/preview_document.js
+++ b/document-apis/preview_document.js
@@ -7,7 +7,7 @@ class PreviewDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -26,7 +26,7 @@ class PreviewDocument {
 
             var previewDocumentInfo = new SDK.V1.PreviewDocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             previewDocumentInfo.setDocumentName("Graphic-Design-Proposal.docx");
 
             previewParameters.setDocumentInfo(previewDocumentInfo);
@@ -59,7 +59,7 @@ class PreviewDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -68,7 +68,7 @@ class PreviewDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -76,7 +76,7 @@ class PreviewDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/document-apis/watermark_document.js
+++ b/document-apis/watermark_document.js
@@ -7,7 +7,7 @@ class WatermarkDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -61,7 +61,7 @@ class WatermarkDocument {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -70,7 +70,7 @@ class WatermarkDocument {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -78,7 +78,7 @@ class WatermarkDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/get_plan_details.js
+++ b/get_plan_details.js
@@ -7,7 +7,7 @@ class GetPlanDetails {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -32,7 +32,7 @@ class GetPlanDetails {
                     } else if (planResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -41,7 +41,7 @@ class GetPlanDetails {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -49,7 +49,7 @@ class GetPlanDetails {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/pdf-apis/delete_pdf_document.js
+++ b/pdf-apis/delete_pdf_document.js
@@ -5,7 +5,7 @@ class DeletePdfDocument {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -35,7 +35,7 @@ class DeletePdfDocument {
                     } else if (pdfDeleteResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", pdfDeleteResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -44,7 +44,7 @@ class DeletePdfDocument {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -52,7 +52,7 @@ class DeletePdfDocument {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/pdf-apis/delete_pdf_session.js
+++ b/pdf-apis/delete_pdf_session.js
@@ -5,7 +5,7 @@ class DeletePdfDocumentSession {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -35,7 +35,7 @@ class DeletePdfDocumentSession {
                     } else if (pdfSessionDeleteResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", pdfSessionDeleteResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -44,7 +44,7 @@ class DeletePdfDocumentSession {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -52,7 +52,7 @@ class DeletePdfDocumentSession {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/pdf-apis/edit_pdf.js
+++ b/pdf-apis/edit_pdf.js
@@ -7,7 +7,7 @@ class EditPDF {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -18,7 +18,7 @@ class EditPDF {
             
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("EventForm.pdf");
 
@@ -82,7 +82,7 @@ class EditPDF {
                     } else if (pdfSessionResponseObj instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", pdfSessionResponseObj);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -91,7 +91,7 @@ class EditPDF {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -99,7 +99,7 @@ class EditPDF {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/pdf-apis/get_pdf_document_detail.js
+++ b/pdf-apis/get_pdf_document_detail.js
@@ -5,7 +5,7 @@ class GetPdfDocumentDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -45,7 +45,7 @@ class GetPdfDocumentDetail {
                         } else if (documentMetaObj instanceof SDK.V1.InvalidConfigurationException) {
                             console.log("\nInvalid configuration exception. Exception json - ", documentMetaObj);
                         } else {
-                            console.log("\nRequest not completed successfullly");
+                            console.log("\nRequest not completed successfully");
                         }
                     }
                 }
@@ -55,7 +55,7 @@ class GetPdfDocumentDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -63,7 +63,7 @@ class GetPdfDocumentDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/pdf-apis/get_pdf_session_detail.js
+++ b/pdf-apis/get_pdf_session_detail.js
@@ -5,7 +5,7 @@ class GetPdfSessionDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -37,7 +37,7 @@ class GetPdfSessionDetail {
                     } else if (showResponseObj instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", showResponseObj);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -46,7 +46,7 @@ class GetPdfSessionDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -54,7 +54,7 @@ class GetPdfSessionDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/coedit_presentation.js
+++ b/presentation-apis/coedit_presentation.js
@@ -7,7 +7,7 @@ class EditPresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -17,9 +17,9 @@ class EditPresentation {
             var documentInfo = new SDK.V1.DocumentInfo();
 
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
-            //Note: Make sure the document already exist in Zoho server for below given document id.
+            //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be create for document already exist with Zoho.
+            //then session will be created for document already exists with Zoho.
             documentInfo.setDocumentId("1000");
 
             createPresentationParameters.setDocumentInfo(documentInfo);
@@ -108,7 +108,7 @@ class EditPresentation {
                                 } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                                     console.log("Invalid configuration exception. Exception json - ", writerResponseObject);
                                 } else {
-                                    console.log("Request not completed successfullly");
+                                    console.log("Request not completed successfully");
                                 }
                             }
                         }
@@ -116,7 +116,7 @@ class EditPresentation {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("Invalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("Request not completed successfullly");
+                        console.log("Request not completed successfully");
                     }
                 }
             }
@@ -125,7 +125,7 @@ class EditPresentation {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -133,7 +133,7 @@ class EditPresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/coedit_presentation.js
+++ b/presentation-apis/coedit_presentation.js
@@ -19,7 +19,7 @@ class EditPresentation {
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
             //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be created for document already exists with Zoho.
+            //then session will be created for the document that already exists with Zoho.
             documentInfo.setDocumentId("1000");
 
             createPresentationParameters.setDocumentInfo(documentInfo);

--- a/presentation-apis/convert_presentation.js
+++ b/presentation-apis/convert_presentation.js
@@ -7,7 +7,7 @@ class ConvertPresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -47,7 +47,7 @@ class ConvertPresentation {
                     } else if (showResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", showResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -56,7 +56,7 @@ class ConvertPresentation {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -64,7 +64,7 @@ class ConvertPresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/create_presentation.js
+++ b/presentation-apis/create_presentation.js
@@ -7,7 +7,7 @@ class CreatePresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -16,7 +16,7 @@ class CreatePresentation {
             
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("New Presentation");
 
@@ -81,7 +81,7 @@ class CreatePresentation {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -90,7 +90,7 @@ class CreatePresentation {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -98,7 +98,7 @@ class CreatePresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/delete_presentation.js
+++ b/presentation-apis/delete_presentation.js
@@ -5,7 +5,7 @@ class DeletePresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -32,7 +32,7 @@ class DeletePresentation {
                     } else if (presentationDeleteResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", presentationDeleteResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -41,7 +41,7 @@ class DeletePresentation {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -49,7 +49,7 @@ class DeletePresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/delete_presentation_session.js
+++ b/presentation-apis/delete_presentation_session.js
@@ -5,7 +5,7 @@ class DeletePresentationSession {
         static async execute() {
             
             //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-            //You can place SDK initializer code in you application and call once while your application start-up. 
+            //You can place SDK initializer code in your application and call once while your application start-up. 
             await this.initializeSdk();
 
         try {
@@ -31,7 +31,7 @@ class DeletePresentationSession {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -40,7 +40,7 @@ class DeletePresentationSession {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -48,7 +48,7 @@ class DeletePresentationSession {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/edit_presentation.js
+++ b/presentation-apis/edit_presentation.js
@@ -7,7 +7,7 @@ class EditPresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -25,7 +25,7 @@ class EditPresentation {
             
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("Zoho_Show.pptx");
 
@@ -90,7 +90,7 @@ class EditPresentation {
                     } else if (presentationResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", presentationResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -99,7 +99,7 @@ class EditPresentation {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -107,7 +107,7 @@ class EditPresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/get_session_detail.js
+++ b/presentation-apis/get_session_detail.js
@@ -5,7 +5,7 @@ class GetSessionDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -34,7 +34,7 @@ class GetSessionDetail {
                     } else if (showResponseObj instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", showResponseObj);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -43,7 +43,7 @@ class GetSessionDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -51,7 +51,7 @@ class GetSessionDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/presentation-apis/preview_presentation.js
+++ b/presentation-apis/preview_presentation.js
@@ -7,7 +7,7 @@ class PreviewPresentation {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -26,7 +26,7 @@ class PreviewPresentation {
 
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("Zoho_Show.pptx");
 
@@ -57,7 +57,7 @@ class PreviewPresentation {
                     } else if (previewResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", previewResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -66,7 +66,7 @@ class PreviewPresentation {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -74,7 +74,7 @@ class PreviewPresentation {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/coedit_sheet.js
+++ b/spreadsheet-apis/coedit_sheet.js
@@ -17,7 +17,7 @@ class EditSheet {
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
             //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be created for document already exists with Zoho.
+            //then session will be created for the document that already exists with Zoho.
             documentInfo.setDocumentId("1000");
             documentInfo.setDocumentName("Contact_List.xlsx");
 

--- a/spreadsheet-apis/coedit_sheet.js
+++ b/spreadsheet-apis/coedit_sheet.js
@@ -5,7 +5,7 @@ class EditSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -15,9 +15,9 @@ class EditSheet {
             var documentInfo = new SDK.V1.DocumentInfo();
 
             //To collaborate in existing document you need to provide the document id(e.g: 1000) alone is enough.
-            //Note: Make sure the document already exist in Zoho server for below given document id.
+            //Note: Make sure the document already exists in Zoho server for below given document id.
             //Even if the document is added to this request, if document exist in zoho server for given document id,
-            //then session will be create for document already exist with Zoho.
+            //then session will be created for document already exists with Zoho.
             documentInfo.setDocumentId("1000");
             documentInfo.setDocumentName("Contact_List.xlsx");
 
@@ -107,18 +107,18 @@ class EditSheet {
                                 } else if (sheetSession2ResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                                     console.log("\nInvalid configuration exception. Exception json - ", sheetSession2ResponseObject);
                                 } else {
-                                    console.log("\nRequest not completed successfullly");
+                                    console.log("\nRequest not completed successfully");
                                 }
                             } else if (sheetSession2ResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                                 console.log("\nInvalid configuration exception in session 2 creation. Exception json - ", sheetResponseObject);
                             } else {
-                                console.log("\nRequest not completed successfullly");
+                                console.log("\nRequest not completed successfully");
                             }
                         }
                     } else if (sheetResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -127,7 +127,7 @@ class EditSheet {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
    static async initializeSdk() {
 
@@ -135,7 +135,7 @@ class EditSheet {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/convert_sheet.js
+++ b/spreadsheet-apis/convert_sheet.js
@@ -7,7 +7,7 @@ class ConvertSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -52,7 +52,7 @@ class ConvertSheet {
                     } else if (sheetResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -61,7 +61,7 @@ class ConvertSheet {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
    static async initializeSdk() {
 
@@ -69,7 +69,7 @@ class ConvertSheet {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/create_sheet.js
+++ b/spreadsheet-apis/create_sheet.js
@@ -5,7 +5,7 @@ class CreateSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -14,7 +14,7 @@ class CreateSheet {
             
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("New Document");
 
@@ -88,7 +88,7 @@ class CreateSheet {
                     } else if (sheetResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -97,7 +97,7 @@ class CreateSheet {
         }
     }
 
-       //Include office-integrator-sdk package in your package json and the execute this code.
+       //Include office-integrator-sdk package in your package json and then execute this code.
 
    static async initializeSdk() {
 
@@ -105,7 +105,7 @@ class CreateSheet {
         let environment = await new SDK.ApiServer.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/delete_sheet.js
+++ b/spreadsheet-apis/delete_sheet.js
@@ -5,7 +5,7 @@ class DeleteSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -32,7 +32,7 @@ class DeleteSheet {
                     } else if (sheetResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -41,7 +41,7 @@ class DeleteSheet {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -49,7 +49,7 @@ class DeleteSheet {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/delete_sheet_session.js
+++ b/spreadsheet-apis/delete_sheet_session.js
@@ -5,7 +5,7 @@ class DeleteSheetSession {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -32,7 +32,7 @@ class DeleteSheetSession {
                     } else if (writerResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", writerResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -41,7 +41,7 @@ class DeleteSheetSession {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -49,7 +49,7 @@ class DeleteSheetSession {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/edit_sheet.js
+++ b/spreadsheet-apis/edit_sheet.js
@@ -7,7 +7,7 @@ class EditSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -26,7 +26,7 @@ class EditSheet {
 
             var documentInfo = new SDK.V1.DocumentInfo();
 
-            //Time value used to generate unique document everytime. You can replace based on your application.
+            //Time value used to generate unique document every time. You can replace based on your application.
             documentInfo.setDocumentId("" + new Date().getTime());
             documentInfo.setDocumentName("Contact_List.xlsx");
 
@@ -88,7 +88,7 @@ class EditSheet {
                     } else if (sheetResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -97,7 +97,7 @@ class EditSheet {
         }
     }
 
-   //Include office-integrator-sdk package in your package json and the execute this code.
+   //Include office-integrator-sdk package in your package json and then execute this code.
 
    static async initializeSdk() {
 
@@ -105,7 +105,7 @@ class EditSheet {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/get_session_detail.js
+++ b/spreadsheet-apis/get_session_detail.js
@@ -5,7 +5,7 @@ class GetSessionDetail {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -35,7 +35,7 @@ class GetSessionDetail {
                     } else if (sheetResponse instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", sheetResponse);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -44,7 +44,7 @@ class GetSessionDetail {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -52,7 +52,7 @@ class GetSessionDetail {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 

--- a/spreadsheet-apis/preview_sheet.js
+++ b/spreadsheet-apis/preview_sheet.js
@@ -7,7 +7,7 @@ class PreviewSheet {
     static async execute() {
         
         //Initializing SDK once is enough. Calling here since code sample will be tested standalone. 
-        //You can place SDK initializer code in you application and call once while your application start-up. 
+        //You can place SDK initializer code in your application and call once while your application start-up. 
         await this.initializeSdk();
 
         try {
@@ -52,7 +52,7 @@ class PreviewSheet {
                     } else if (previewResponseObject instanceof SDK.V1.InvalidConfigurationException) {
                         console.log("\nInvalid configuration exception. Exception json - ", previewResponseObject);
                     } else {
-                        console.log("\nRequest not completed successfullly");
+                        console.log("\nRequest not completed successfully");
                     }
                 }
             }
@@ -61,7 +61,7 @@ class PreviewSheet {
         }
     }
 
-    //Include office-integrator-sdk package in your package json and the execute this code.
+    //Include office-integrator-sdk package in your package json and then execute this code.
 
     static async initializeSdk() {
 
@@ -69,7 +69,7 @@ class PreviewSheet {
         let environment = await new SDK.DataCenter.Production("https://api.office-integrator.com");
 
         let auth = new SDK.AuthBuilder()
-                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office inetgrator service
+                        .addParam("apikey", "2ae438cf864488657cc9754a27daa480") //Update this apikey with your own apikey signed up in office integrator service
                         .authenticationSchema(await new SDK.V1.Authentication().getTokenFlow())
                         .build();
 


### PR DESCRIPTION
## Summary
- Fix 7 recurring typos in JS code comments across all 39 example files (176 occurrences total)
- Typos corrected: `you application` → `your application`, `everytime` → `every time`, `successfullly` → `successfully`, `the execute` → `then execute`, `inetgrator` → `integrator`, `will be create` → `will be created`, `already exist` → `already exists`
- Comments only — no functional code changes